### PR TITLE
[fixed] default props has to be a function

### DIFF
--- a/InfiniteScroller.js
+++ b/InfiniteScroller.js
@@ -17,9 +17,11 @@ const InfiniteScoller = React.createClass({
     onScroll: PropTypes.func,
   },
 
-  defaultProps: {
-    onScroll: noop,
-    containerClassName: 'infiniteContainer',
+  getDefaultProps() {
+    return {
+      onScroll: noop,
+      containerClassName: 'infiniteContainer',
+    };
   },
 
   onEditorScroll(event) {


### PR DESCRIPTION
My bad, I noticed I defined defaultProps as I normally do for es6 classes, but this is a react.createClass so it has to be defined as a function! 

https://facebook.github.io/react/docs/reusable-components.html#default-prop-values
