### PR TITLE
Provide custom inline styles

### DIFF
--- a/InfiniteScroller.js
+++ b/InfiniteScroller.js
@@ -16,6 +16,7 @@ const InfiniteScoller = React.createClass({
     jumpToBottomOfRow: PropTypes.bool,
     containerClassName: PropTypes.string,
     onScroll: PropTypes.func,
+    style: PropTypes.object,
   },
 
   getDefaultProps() {
@@ -264,7 +265,7 @@ const InfiniteScoller = React.createClass({
       <div
         ref="infiniteContainer"
         className={this.props.containerClassName}
-        style={infiniteContainerStyle}
+        style={Object.assign(infiniteContainerStyle, this.props.style || {})}
         onScroll={this.onEditorScroll}
       >
         <div className="topSpacer" style={{height: this.topSpacerHeight}}/>

--- a/bundle.js
+++ b/bundle.js
@@ -16781,15 +16781,21 @@
 	 * @typechecks
 	 */
 
+	/* eslint-disable fb-www/typeof-undefined */
+
 	/**
 	 * Same as document.activeElement but wraps in a try-catch block. In IE it is
 	 * not safe to call document.activeElement if there is nothing focused.
 	 *
-	 * The activeElement will be null only if the document body is not yet defined.
+	 * The activeElement will be null only if the document or document body is not
+	 * yet defined.
 	 */
-	"use strict";
+	'use strict';
 
 	function getActiveElement() /*?DOMElement*/{
+	  if (typeof document === 'undefined') {
+	    return null;
+	  }
 	  try {
 	    return document.activeElement || document.body;
 	  } catch (e) {
@@ -18788,7 +18794,7 @@
 
 	'use strict';
 
-	module.exports = '0.14.5';
+	module.exports = '0.14.6';
 
 /***/ },
 /* 147 */
@@ -19787,7 +19793,8 @@
 	    }),
 	    jumpToBottomOfRow: _react.PropTypes.bool,
 	    containerClassName: _react.PropTypes.string,
-	    onScroll: _react.PropTypes.func
+	    onScroll: _react.PropTypes.func,
+	    style: _react.PropTypes.object
 	  },
 
 	  getDefaultProps: function getDefaultProps() {
@@ -20042,7 +20049,7 @@
 	      {
 	        ref: 'infiniteContainer',
 	        className: this.props.containerClassName,
-	        style: infiniteContainerStyle,
+	        style: Object.assign(infiniteContainerStyle, this.props.style || {}),
 	        onScroll: this.onEditorScroll
 	      },
 	      _react2['default'].createElement('div', { className: 'topSpacer', style: { height: this.topSpacerHeight } }),

--- a/index.js
+++ b/index.js
@@ -31,7 +31,8 @@ var InfiniteScoller = _react2['default'].createClass({
     }),
     jumpToBottomOfRow: _react.PropTypes.bool,
     containerClassName: _react.PropTypes.string,
-    onScroll: _react.PropTypes.func
+    onScroll: _react.PropTypes.func,
+    style: _react.PropTypes.object
   },
 
   getDefaultProps: function getDefaultProps() {
@@ -286,7 +287,7 @@ var InfiniteScoller = _react2['default'].createClass({
       {
         ref: 'infiniteContainer',
         className: this.props.containerClassName,
-        style: infiniteContainerStyle,
+        style: Object.assign(infiniteContainerStyle, this.props.style || {}),
         onScroll: this.onEditorScroll
       },
       _react2['default'].createElement('div', { className: 'topSpacer', style: { height: this.topSpacerHeight } }),


### PR DESCRIPTION
If using inline styles it is convenient to be able to pass styles rather than just class names. 

Being able to provide a height in relative units is also a useful scenario, which this PR makes possible. While `containerHeight` provides a "Maximum height of the scroll container", it seems perfectly OK to provide a relative height for the rendering, as long as `containerHeight` is greater. I therefore let the custom styles override the default styles, and not vice versa. Please correct me if I am wrong. 
